### PR TITLE
CentOS 6.7, vagrant ssh key issues, SCL repo update and double quote escape issue in mailcatcher

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,11 +10,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "CentOS-6.5-x86_64"
+  config.vm.box = "CentOS-6.7-x86_64"
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  config.vm.box_url = "http://developer.nrel.gov/downloads/vagrant-boxes/CentOS-6.5-x86_64-v20140311.box"
+  config.vm.box_url = "https://svwh.dl.sourceforge.net/project/nrel-vagrant-boxes/CentOS-6.7-x86_64-v20151108.box"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
@@ -37,6 +37,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # If true, then any SSH connections made will enable agent forwarding.
   # Default value: false
   # config.ssh.forward_agent = true
+  config.ssh.insert_key = false
 
   # Mount the parent directory at /mnt/project
   config.vm.synced_folder "../", "/mnt/project",

--- a/cookbooks/mailcatcher/recipes/default.rb
+++ b/cookbooks/mailcatcher/recipes/default.rb
@@ -35,7 +35,7 @@ end
 # install MailCatcher
 execute "install mailcatcher" do
   command <<-EOL
-    scl enable ruby193 'gem install mime-types --version "< 3"'
+    scl enable ruby193 'gem install mime-types --version \"< 3\"'
     scl enable ruby193 'gem install --conservative mailcatcher -v 0.6.1'
   EOL
   user "root"

--- a/cookbooks/scl/recipes/default.rb
+++ b/cookbooks/scl/recipes/default.rb
@@ -24,7 +24,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
-yum_package "centos-release-SCL" do
+yum_package "centos-release-scl-rh" do
   action :install
 end
 


### PR DESCRIPTION
Updated to CentOS 6.7
When using a newer Vagrant there seems to be an ssh key issue. I'm using Vagrant v1.8.5
The SCL repo package name changed.
The scl command was failing within the mailcatcher recipe because of an unescaped double quote. 